### PR TITLE
Fix typos

### DIFF
--- a/cpp.js
+++ b/cpp.js
@@ -60,10 +60,11 @@ define(function(require, exports, module) {
 
         // Calls a clang_remote function, uses rate limitting
         function callRemoteLimited(fcn, params) {
+            var tries = 0;
             setupServerFcn();
 
             // Initiates a server call
-            function setupServerFcn(tries = 0) {
+            function setupServerFcn() {
                 var waiting = lastServerCall + callInterval - Date.now();
                 if (waiting > 0) {
                     // only set pending on first try

--- a/install.js
+++ b/install.js
@@ -5,7 +5,7 @@ module.exports = function(session, options){
     //session.preInstallScript = require("text!./check-deps.sh");
 
     // libclang pkgs
-    var pkgs = ['llvm-3.5', 'llvm-3.5-dev', 'lvm-3.5-runtime', 'libclang-3.5-dev', 'libclang1-3.5'];
+    var pkgs = ['llvm-3.5', 'llvm-3.5-dev', 'llvm-3.5-runtime', 'libclang-3.5-dev', 'libclang1-3.5'];
 
     for (var i = 0; i < pkgs.length; ++i) {
         session.install({


### PR DESCRIPTION
In our opinion there are two issues/typos in code:

install.js: The package is named "llvm-3.5-runtime" on Ubuntu from what we can see.
cpp.js: The declaration of the 'tries' variable for the setupServerFcn is suspicious. Uglify is failing and in our experience the plug-in isn't loading with this kind of variable declaration.
