### PR TITLE
Fix editor not scrolling to symbol position

### DIFF
--- a/cpp_worker.js
+++ b/cpp_worker.js
@@ -245,9 +245,11 @@ define(function(require, exports, module) {
         // @todo: take access specifier into account (green = public, blue = protected, red = private)
         var parseAst = function (ast, item) {
             _.forEach(ast, function (ele) {
+                var row = ele.loc_row - 1;
+                var col = ele.loc_col - 1;
                 var toPush = {
-                    pos: { sl: ele.loc_row - 1, sc: ele.loc_col - 1 },
-                    displayPos: { sl: ele.loc_row - 1, sc: ele.loc_col - 1 },
+                    pos: { sl: row, sc: col, el: row, ec: col },
+                    displayPos: { sl: row, sc: col, el : row, ec: col },
                     items: [],
                     name: ele.name
                 };


### PR DESCRIPTION
If clicking on a symbol in the outline, the editor is jumping to the symbol but is not revealing the line. The behavior is caused by not setting the end line and end column positions for the symbol.
